### PR TITLE
Fix update order when pulling repositories

### DIFF
--- a/src/application/git.rs
+++ b/src/application/git.rs
@@ -37,11 +37,11 @@ pub async fn handle_existing_repo(
     }?;
 
     if remote_ahead {
-        pull_latest_changes(git_project_path.to_str().unwrap(), auth.branch.clone())
-            .map_err(ErrorArrayItem::from)?;
-
         checkout_branch(&repo, auth.branch.clone())
             .map_err(|err| ErrorArrayItem::new(Errors::Git, err.message()))?;
+
+        pull_latest_changes(git_project_path.to_str().unwrap(), auth.branch.clone())
+            .map_err(ErrorArrayItem::from)?;
 
         log!(
             LogLevel::Info,


### PR DESCRIPTION
## Summary
- check out the branch in `handle_existing_repo` before pulling updates

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685053f185d4832d90215a015f9caf98