### PR TITLE
Improve git interaction reliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "config 0.14.1",
  "dusa_collection_utils 3.2.1",
  "git2",
+ "once_cell",
  "rand 0.8.5",
  "rng",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "ais_gitmon"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "artisan_middleware",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ name = "ais_gitmon"
 version = "2.3.0"
 dependencies = [
  "artisan_middleware",
+ "base64 0.22.1",
  "colored",
  "config 0.14.1",
  "dusa_collection_utils 3.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,6 @@ dependencies = [
  "colored",
  "config 0.14.1",
  "dusa_collection_utils 3.2.1",
- "git2",
  "once_cell",
  "rand 0.8.5",
  "rng",
@@ -328,8 +327,6 @@ version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -964,21 +961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "git2"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
-dependencies = [
- "bitflags 2.6.0",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,15 +1405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,20 +1448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.0+1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,32 +1456,6 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
  "redox_syscall 0.5.8",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ colored = "2.1.0"
 signals = "0.0.5"
 signal-hook = "0.3.17"
 git2 = "0.20.0"
+once_cell = "1.20.2"
 
 [[bin]]
 name = "ais_gitmon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ais_gitmon"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ colored = "2.1.0"
 signals = "0.0.5"
 signal-hook = "0.3.17"
 once_cell = "1.20.2"
+base64 = "0.22.1"
 
 [[bin]]
 name = "ais_gitmon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ rand = "0.8.5"
 colored = "2.1.0"
 signals = "0.0.5"
 signal-hook = "0.3.17"
-git2 = "0.20.0"
 once_cell = "1.20.2"
 
 [[bin]]

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -1,4 +1,17 @@
+use once_cell::sync::OnceCell;
 use std::process::Command;
+
+static GH_TOKEN: OnceCell<String> = OnceCell::new();
+
+pub fn init_gh_token() -> std::io::Result<()> {
+    let token = get_gh_token()?;
+    let _ = GH_TOKEN.set(token);
+    Ok(())
+}
+
+pub fn github_token() -> Option<&'static str> {
+    GH_TOKEN.get().map(|s| s.as_str())
+}
 
 pub fn get_gh_token() -> std::io::Result<String> {
     let output = Command::new("gh").arg("auth").arg("token").output()?;

--- a/src/application/auth.rs
+++ b/src/application/auth.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::OnceCell;
 use std::process::Command;
+use base64::{engine::general_purpose, Engine as _};
 
 static GH_TOKEN: OnceCell<String> = OnceCell::new();
 
@@ -11,6 +12,14 @@ pub fn init_gh_token() -> std::io::Result<()> {
 
 pub fn github_token() -> Option<&'static str> {
     GH_TOKEN.get().map(|s| s.as_str())
+}
+
+pub fn github_auth_header() -> Option<String> {
+    github_token().map(|token| {
+        let creds = format!("x-access-token:{}", token);
+        let encoded = general_purpose::STANDARD.encode(creds);
+        format!("Authorization: Basic {}", encoded)
+    })
 }
 
 pub fn get_gh_token() -> std::io::Result<String> {

--- a/src/application/git.rs
+++ b/src/application/git.rs
@@ -8,8 +8,8 @@ use dusa_collection_utils::{
     types::pathtype::PathType,
 };
 use dusa_collection_utils::{functions::truncate, log};
-use tokio::process::Command;
 use once_cell::sync::Lazy;
+use tokio::process::Command;
 use tokio::sync::Mutex;
 
 use crate::{
@@ -148,7 +148,7 @@ pub async fn fetch_updates(git_project_path: &PathType) -> Result<(), ErrorArray
         }
     };
 
-    let header = format!("AUTHORIZATION: Bearer {}", token);
+    let header = format!("Authorization: Bearer {}", token);
     let output = Command::new("git")
         .arg("-C")
         .arg(git_project_path.to_string())
@@ -170,7 +170,10 @@ pub async fn fetch_updates(git_project_path: &PathType) -> Result<(), ErrorArray
 }
 
 // Check if the upstream branch is ahead of the local branch
-async fn is_remote_ahead(auth: &GitAuth, git_project_path: &PathType) -> Result<bool, std::io::Error> {
+async fn is_remote_ahead(
+    auth: &GitAuth,
+    git_project_path: &PathType,
+) -> Result<bool, std::io::Error> {
     let local = Command::new("git")
         .arg("-C")
         .arg(git_project_path.to_string())
@@ -190,8 +193,16 @@ async fn is_remote_ahead(auth: &GitAuth, git_project_path: &PathType) -> Result<
     let local_commit = String::from_utf8_lossy(&local.stdout).trim().to_string();
     let remote_commit = String::from_utf8_lossy(&remote.stdout).trim().to_string();
 
-    log!(LogLevel::Trace, "Latest commit on remote: {}", truncate(remote_commit.clone(), 8));
-    log!(LogLevel::Trace, "Latest local commit: {}", truncate(local_commit.clone(), 8));
+    log!(
+        LogLevel::Trace,
+        "Latest commit on remote: {}",
+        truncate(remote_commit.clone(), 8)
+    );
+    log!(
+        LogLevel::Trace,
+        "Latest local commit: {}",
+        truncate(local_commit.clone(), 8)
+    );
 
     Ok(local_commit != remote_commit)
 }

--- a/src/application/git.rs
+++ b/src/application/git.rs
@@ -8,7 +8,7 @@ use dusa_collection_utils::{
     types::pathtype::PathType,
 };
 use dusa_collection_utils::{functions::truncate, log};
-use git2::{Cred, FetchOptions, RemoteCallbacks, Repository};
+use tokio::process::Command;
 
 use crate::{
     auth::github_token,
@@ -18,7 +18,6 @@ use crate::{
 // Handle an existing repo: fetch, pull if upstream is ahead, set tracking, restart if needed
 pub async fn handle_existing_repo(
     auth: &GitAuth,
-    repo: Repository,
     git_project_path: &PathType,
 ) -> Result<(), ErrorArrayItem> {
     log!(
@@ -27,20 +26,20 @@ pub async fn handle_existing_repo(
         auth.generate_id()
     );
 
-    // set_safe_directory(git_project_path).await?;
-    fetch_updates(&repo).await?;
+    fetch_updates(git_project_path).await?;
 
-    // Check if upstream is ahead
-    let remote_ahead: bool = match is_remote_ahead(auth, &repo).await {
+    let remote_ahead: bool = match is_remote_ahead(auth, git_project_path).await {
         Ok(b) => Ok(b),
-        Err(err) => Err(ErrorArrayItem::new(Errors::Git, err.message())),
+        Err(err) => Err(ErrorArrayItem::new(Errors::Git, err.to_string())),
     }?;
 
     if remote_ahead {
-        checkout_branch(&repo, auth.branch.clone())
-            .map_err(|err| ErrorArrayItem::new(Errors::Git, err.message()))?;
+        checkout_branch(git_project_path.to_str().unwrap(), auth.branch.clone())
+            .await
+            .map_err(ErrorArrayItem::from)?;
 
         pull_latest_changes(git_project_path.to_str().unwrap(), auth.branch.clone())
+            .await
             .map_err(ErrorArrayItem::from)?;
 
         log!(
@@ -62,7 +61,8 @@ pub async fn handle_new_repo(
     // Clone the repository
     let repo_url = auth.assemble_remote_url();
     clone_repo(&repo_url, git_project_path)
-        .map_err(|err| ErrorArrayItem::new(Errors::Git, err.message()))?;
+        .await
+        .map_err(|err| ErrorArrayItem::new(Errors::Git, err.to_string()))?;
 
     // Set ownership to the web user
     let webuser = get_id("www-data")?;
@@ -71,11 +71,9 @@ pub async fn handle_new_repo(
     // Set safe directory
     set_safe_directory(git_project_path).await?;
 
-    let repo = Repository::open(git_project_path)
-        .map_err(|err| ErrorArrayItem::new(Errors::Git, err.message()))?;
-
-    checkout_branch(&repo, auth.branch.clone())
-        .map_err(|err| ErrorArrayItem::new(Errors::Git, err.message()))?;
+    checkout_branch(git_project_path.to_str().unwrap(), auth.branch.clone())
+        .await
+        .map_err(ErrorArrayItem::from)?;
 
     Ok(())
 }
@@ -96,11 +94,11 @@ pub async fn set_safe_directory(git_project_path: &PathType) -> Result<(), Error
 }
 
 // Fetch updates from the remote repository
-pub async fn fetch_updates(repo: &Repository) -> Result<(), ErrorArrayItem> {
+pub async fn fetch_updates(git_project_path: &PathType) -> Result<(), ErrorArrayItem> {
     log!(
         LogLevel::Debug,
         "Fetching updates for, {}",
-        PathType::Path(repo.path().into())
+        git_project_path
     );
 
     let token: &'static str = match github_token() {
@@ -113,52 +111,50 @@ pub async fn fetch_updates(repo: &Repository) -> Result<(), ErrorArrayItem> {
         }
     };
 
-    // Authentication callback
-    let mut auth_cb = RemoteCallbacks::new();
-    auth_cb.credentials(move |_url, username_from_url, _allowed_types| {
-        Cred::userpass_plaintext(
-            username_from_url.unwrap_or("oauth2"), // GitHub accepts "x-access-token" or "oauth2" as user
-            &token,
-        )
-    });
+    let header = format!("AUTHORIZATION: Bearer {}", token);
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(git_project_path.to_string())
+        .arg("-c")
+        .arg(format!("http.extraheader={}", header))
+        .arg("fetch")
+        .arg("origin")
+        .output()
+        .await;
 
-    // TODO allow changing the remote from origin
-
-    match repo.find_remote("origin") {
-        Ok(mut remote) => {
-            let mut fetch_options = FetchOptions::new();
-            fetch_options.remote_callbacks(auth_cb);
-
-            if let Err(err) = remote.fetch(
-                &["+refs/heads/*:refs/remotes/origin/*"],
-                Some(&mut fetch_options),
-                None,
-            ) {
-                Err(ErrorArrayItem::new(Errors::Git, err.message()))
-            } else {
-                Ok(())
-            }
-        }
-        Err(err) => Err(ErrorArrayItem::new(Errors::Git, err.message())),
+    match output {
+        Ok(out) if out.status.success() => Ok(()),
+        Ok(out) => Err(ErrorArrayItem::new(
+            Errors::Git,
+            format!("git fetch failed: {}", String::from_utf8_lossy(&out.stderr)),
+        )),
+        Err(e) => Err(ErrorArrayItem::new(Errors::Git, e.to_string())),
     }
 }
 
 // Check if the upstream branch is ahead of the local branch
-async fn is_remote_ahead(auth: &GitAuth, repo: &Repository) -> Result<bool, git2::Error> {
-    let head = repo.head()?.peel_to_commit()?;
-    let remote_ref = repo.refname_to_id(&format!("refs/remotes/origin/{}", auth.branch))?;
-    let remote_commit = repo.find_commit(remote_ref)?;
+async fn is_remote_ahead(auth: &GitAuth, git_project_path: &PathType) -> Result<bool, std::io::Error> {
+    let local = Command::new("git")
+        .arg("-C")
+        .arg(git_project_path.to_string())
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .await?;
 
-    log!(
-        LogLevel::Debug,
-        "Latest commit on remote: {}",
-        truncate(format!("{}", remote_commit.id()), 8)
-    );
-    log!(
-        LogLevel::Debug,
-        "Latest local commit: {}",
-        truncate(format!("{}", head.id()), 8)
-    );
+    let remote = Command::new("git")
+        .arg("-C")
+        .arg(git_project_path.to_string())
+        .arg("rev-parse")
+        .arg(format!("origin/{}", auth.branch))
+        .output()
+        .await?;
 
-    Ok(head.id() != remote_commit.id())
+    let local_commit = String::from_utf8_lossy(&local.stdout).trim().to_string();
+    let remote_commit = String::from_utf8_lossy(&remote.stdout).trim().to_string();
+
+    log!(LogLevel::Trace, "Latest commit on remote: {}", truncate(remote_commit.clone(), 8));
+    log!(LogLevel::Trace, "Latest local commit: {}", truncate(local_commit.clone(), 8));
+
+    Ok(local_commit != remote_commit)
 }

--- a/src/application/git.rs
+++ b/src/application/git.rs
@@ -13,7 +13,7 @@ use tokio::process::Command;
 use tokio::sync::Mutex;
 
 use crate::{
-    auth::github_token,
+    auth::github_auth_header,
     pull::{checkout_branch, clone_repo, pull_latest_changes},
 };
 
@@ -138,8 +138,8 @@ pub async fn fetch_updates(git_project_path: &PathType) -> Result<(), ErrorArray
         git_project_path
     );
 
-    let token: &'static str = match github_token() {
-        Some(t) => t,
+    let header: String = match github_auth_header() {
+        Some(h) => h,
         None => {
             return Err(ErrorArrayItem::new(
                 Errors::Git,
@@ -147,8 +147,6 @@ pub async fn fetch_updates(git_project_path: &PathType) -> Result<(), ErrorArray
             ));
         }
     };
-
-    let header = format!("Authorization: Bearer {}", token);
     let output = Command::new("git")
         .arg("-C")
         .arg(git_project_path.to_string())
@@ -156,6 +154,7 @@ pub async fn fetch_updates(git_project_path: &PathType) -> Result<(), ErrorArray
         .arg(format!("http.extraheader={}", header))
         .arg("fetch")
         .arg("origin")
+        .env("GIT_TERMINAL_PROMPT", "0")
         .output()
         .await;
 

--- a/src/application/git_auth_store.rs
+++ b/src/application/git_auth_store.rs
@@ -1,0 +1,14 @@
+use artisan_middleware::git_actions::GitAuth;
+use dusa_collection_utils::types::rwarc::LockWithTimeout;
+use once_cell::sync::OnceCell;
+
+static AUTH_BOX: OnceCell<Box<Vec<LockWithTimeout<GitAuth>>>> = OnceCell::new();
+
+pub fn init_auth_box(items: Vec<GitAuth>) {
+    let locked: Vec<LockWithTimeout<GitAuth>> = items.into_iter().map(LockWithTimeout::new).collect();
+    let _ = AUTH_BOX.set(Box::new(locked));
+}
+
+pub fn auth_items() -> Option<&'static Vec<LockWithTimeout<GitAuth>>> {
+    AUTH_BOX.get().map(|v| &**v)
+}

--- a/src/application/pull.rs
+++ b/src/application/pull.rs
@@ -4,20 +4,18 @@ use dusa_collection_utils::types::pathtype::PathType;
 use dusa_collection_utils::types::stringy::Stringy;
 use tokio::process::Command;
 
-use crate::auth::github_token;
+use crate::auth::{github_token, github_auth_header};
 
 /// Pulls the latest changes using `git pull`.
 pub async fn pull_latest_changes(repo_path: &str, branch_name: Stringy) -> std::io::Result<()> {
-    let token: &'static str = match github_token() {
-        Some(t) => t,
+    let header: String = match github_auth_header() {
+        Some(h) => h,
         None => {
             let err =
                 std::io::Error::new(std::io::ErrorKind::Other, "GitHub token not initialized");
             return Err(err);
         }
     };
-
-    let header = format!("Authorization: Bearer {}", token);
     let output = Command::new("git")
         .arg("-C")
         .arg(repo_path)
@@ -27,6 +25,7 @@ pub async fn pull_latest_changes(repo_path: &str, branch_name: Stringy) -> std::
         .arg("origin")
         .arg(branch_name)
         .arg("--rebase")
+        .env("GIT_TERMINAL_PROMPT", "0")
         .output()
         .await?;
 

--- a/src/application/pull.rs
+++ b/src/application/pull.rs
@@ -2,14 +2,12 @@ use dusa_collection_utils::logger::LogLevel;
 use dusa_collection_utils::types::pathtype::PathType;
 use dusa_collection_utils::types::stringy::Stringy;
 use dusa_collection_utils::log;
-use git2::build::RepoBuilder;
-use git2::{BranchType, Cred, FetchOptions, RemoteCallbacks, Repository};
-use std::process::Command;
+use tokio::process::Command;
 
 use crate::auth::github_token;
 
 /// Pulls the latest changes using `git pull`.
-pub fn pull_latest_changes(repo_path: &str, branch_name: Stringy) -> std::io::Result<()> {
+pub async fn pull_latest_changes(repo_path: &str, branch_name: Stringy) -> std::io::Result<()> {
     let output = Command::new("git")
         .arg("-C")
         .arg(repo_path)
@@ -17,7 +15,8 @@ pub fn pull_latest_changes(repo_path: &str, branch_name: Stringy) -> std::io::Re
         .arg("origin")
         .arg(branch_name)
         .arg("--rebase")
-        .output()?;
+        .output()
+        .await?;
 
     if output.status.success() {
         log!(
@@ -37,68 +36,55 @@ pub fn pull_latest_changes(repo_path: &str, branch_name: Stringy) -> std::io::Re
 }
 
 /// Clones the repository if it does not exist.
-pub fn clone_repo(repo_url: &str, dest_path: &PathType) -> Result<(), git2::Error> {
-    if !dest_path.exists() {
-        log!(LogLevel::Info, "Cloning repository into {}", dest_path);
-
-        let token: &'static str = match github_token() {
-            Some(t) => t,
-            None => {
-                log!(LogLevel::Error, "GitHub token not initialized");
-                return Ok(());
-            }
-        };
-
-        let mut callbacks = RemoteCallbacks::new();
-        callbacks.credentials(move |_url, username_from_url, _allowed_types| {
-            Cred::userpass_plaintext(username_from_url.unwrap_or("oauth2"), token)
-        });
-
-        let mut fetch_options = FetchOptions::new();
-        fetch_options.remote_callbacks(callbacks);
-
-        let mut builder = RepoBuilder::new();
-        builder.fetch_options(fetch_options);
-        builder.clone(repo_url, &dest_path)?;
-    }
-    Ok(())
-}
-
-pub fn branch_exists(repo: &Repository, branch_name: Stringy) -> bool {
-    repo.find_branch(&branch_name, BranchType::Local).is_ok()
-}
-
-/// Creates a local tracking branch if it does not exist.
-fn create_tracking_branch(repo: &Repository, branch_name: &str) -> Result<(), git2::Error> {
-    let remote_branch_ref = format!("refs/remotes/origin/{}", branch_name);
-    let remote_branch = repo.refname_to_id(&remote_branch_ref)?;
-
-    let commit = repo.find_commit(remote_branch)?;
-    repo.branch(branch_name, &commit, false)?;
-
-    Ok(())
-}
-
-/// Switches to the specified branch (creates it if necessary).
-pub fn checkout_branch(repo: &Repository, branch_name: Stringy) -> Result<(), git2::Error> {
-    if !branch_exists(repo, branch_name.clone()) {
-        log!(
-            LogLevel::Debug,
-            "Branch '{}' does not exist locally. Creating a tracking branch...",
-            branch_name
-        );
-        create_tracking_branch(repo, &branch_name)?;
+pub async fn clone_repo(repo_url: &str, dest_path: &PathType) -> std::io::Result<()> {
+    if dest_path.exists() {
+        return Ok(());
     }
 
-    let branch_ref = format!("refs/heads/{}", branch_name);
-    let obj = repo.revparse_single(&branch_ref)?;
+    log!(LogLevel::Info, "Cloning repository into {}", dest_path);
 
-    let mut checkout_opts = git2::build::CheckoutBuilder::new();
-    repo.checkout_tree(&obj, Some(&mut checkout_opts))?;
+    let token: &'static str = match github_token() {
+        Some(t) => t,
+        None => {
+            log!(LogLevel::Error, "GitHub token not initialized");
+            return Ok(());
+        }
+    };
 
-    repo.set_head(&branch_ref)?;
+    let url_with_token = repo_url.replace("https://", &format!("https://oauth2:{}@", token));
+    let output = Command::new("git")
+        .arg("clone")
+        .arg(url_with_token)
+        .arg(dest_path.to_string())
+        .output()
+        .await?;
 
-    log!(LogLevel::Debug, "Switched to branch '{}'", branch_name);
+    if output.status.success() {
+        Ok(())
+    } else {
+        let msg = format!("git clone failed: {}", String::from_utf8_lossy(&output.stderr));
+        Err(std::io::Error::new(std::io::ErrorKind::Other, msg))
+    }
+}
 
-    Ok(())
+/// Switches to the specified branch.
+pub async fn checkout_branch(repo_path: &str, branch_name: Stringy) -> std::io::Result<()> {
+    let branch = branch_name.to_string();
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_path)
+        .arg("checkout")
+        .arg("-B")
+        .arg(&branch)
+        .arg(format!("origin/{}", branch))
+        .output()
+        .await?;
+
+    if output.status.success() {
+        log!(LogLevel::Debug, "Switched to branch '{}'", branch);
+        Ok(())
+    } else {
+        let msg = format!("git checkout failed: {}", String::from_utf8_lossy(&output.stderr));
+        Err(std::io::Error::new(std::io::ErrorKind::Other, msg))
+    }
 }


### PR DESCRIPTION
## Summary
- cache GitHub token globally on startup
- avoid logging tokens and return errors on failed pulls
- checkout branch before pulling and compare full commit IDs
- spawn per-repo workers on separate threads
- fix typos in warning messages

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6850533d0888832dbca7e98fdbdc09b4